### PR TITLE
Make functional test quicker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ jobs:
         - PREFIX=nightly
         - INSTANCEMGR_TAG=master
       script:
-      - while sleep 9m; do echo "=====[ keepalive ]====="; done &
-      - make env-create
       - export SECURITY_GROUPS=$(aws cloudformation describe-stacks --stack-name $PREFIX-eks-node-security-group --query "Stacks[0].Outputs[?OutputKey=='SecurityGroup'].OutputValue" --output text)
-      - make bdd; ret=$?; make env-delete; exit $ret
-      - kill %1
+      - aws eks update-kubeconfig --name $EKS_CLUSTER
+      - make bdd

--- a/test-bdd/templates/instance-group-crd.yaml
+++ b/test-bdd/templates/instance-group-crd.yaml
@@ -21,8 +21,8 @@ spec:
           name: rollup-nodes
           namespace: instance-manager
         spec:
-          postDrainDelaySeconds: 90
-          nodeIntervalSeconds: 300
+          postDrainDelaySeconds: 30
+          nodeIntervalSeconds: 180
           region: {{`{{ .ControllerRegion }}`}}
           asgName: {{`{{ .InstanceGroup.Status.ActiveScalingGroupName }}`}}
   eks-cf:


### PR DESCRIPTION
Fixes #15 

- Gets rid of cluster create/delete for every test (-40 minutes~)
- Make upgrade-manager post drain/kill shorter

Tests should not take more than 20 minutes now.

## Testing
- Ran this on my fork - job is no longer timing out