### PR TITLE
CRD Strategy: fix concurrency of multiple instancegroups

### DIFF
--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -199,3 +199,10 @@ func (d *DiscoveredInstanceGroup) GetLaunchConfigName() string {
 	}
 	return ""
 }
+
+func (d *DiscoveredInstanceGroup) GetScalingGroupName() string {
+	if d != nil {
+		return d.ScalingGroupName
+	}
+	return ""
+}


### PR DESCRIPTION
Fixes #20 
- Adds another annotation to CR that defines the scope of the concurrency lock (scaling group name).

## Testing
- Tested manually to verify the bug, and the fix for the bug.