### PR TITLE
Retain existing aws-auth mapRoles

### DIFF
--- a/controllers/provisioners/ekscloudformation/ekscloudformation.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation.go
@@ -253,7 +253,6 @@ func (ctx *EksCfInstanceGroupContext) discoverInstanceGroups() {
 
 	for _, stack := range stacks {
 		var group DiscoveredInstanceGroup
-		group.ClusterName = aws.StringValue(stack.StackName)
 		group.StackName = aws.StringValue(stack.StackName)
 
 		for _, tag := range stack.Tags {

--- a/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
@@ -888,8 +888,8 @@ func TestGetActiveNodesARN(t *testing.T) {
 func TestUpdateAuthConfigMap(t *testing.T) {
 	ctx := getBasicContext(t, blankMocker)
 	ctx.fakeBootstrapState()
-	cm, _ := ctx.createEmptyNodesAuthConfigMap()
-	ctx.updateAuthConfigMap(cm)
+	ctx.createEmptyNodesAuthConfigMap()
+	ctx.updateAuthConfigMap()
 	expectedActiveARNs := []string{
 		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/arn-1",
 		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/arn-2",

--- a/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
@@ -870,30 +870,15 @@ func TestCrdStrategyCRLongName(t *testing.T) {
 	testCase.Run(t)
 }
 
-func TestGetActiveNodesARN(t *testing.T) {
-	ctx := getBasicContext(t, blankMocker)
-	ctx.fakeBootstrapState()
-
-	expectedActiveARNs := []string{
-		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/arn-1",
-		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/arn-2",
-		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/discoveredARN",
-	}
-	nodesArn := ctx.getActiveNodeArns()
-	if !reflect.DeepEqual(nodesArn, expectedActiveARNs) {
-		t.Fatalf("getActiveNodeArns returned: %v, expected: %v", nodesArn, expectedActiveARNs)
-	}
-}
-
 func TestUpdateAuthConfigMap(t *testing.T) {
 	ctx := getBasicContext(t, blankMocker)
 	ctx.fakeBootstrapState()
 	ctx.createEmptyNodesAuthConfigMap()
 	ctx.updateAuthConfigMap()
 	expectedActiveARNs := []string{
+		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/discoveredARN",
 		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/arn-1",
 		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/arn-2",
-		"arn:aws:autoscaling:region:account-id:autoScalingGroup:groupid:autoScalingGroupName/discoveredARN",
 	}
 	var expectedAuthMap string
 	for _, arn := range expectedActiveARNs {

--- a/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
@@ -201,6 +201,7 @@ func (s *stubCF) DescribeStacks(input *cloudformation.DescribeStacksInput) (*clo
 				ResourceName:  instanceGroupName,
 				StackState:    s.StackState,
 				StackARN:      arn,
+				StackName:     "stack-name",
 			}
 			existingStack := createFakeStack(fakeStackInput)
 			existingStacks = append(existingStacks, existingStack)
@@ -215,6 +216,7 @@ func (s *stubCF) DescribeStacks(input *cloudformation.DescribeStacksInput) (*clo
 			ResourceName:  s.InstanceGroup.ObjectMeta.Name,
 			StackState:    s.StackState,
 			StackARN:      s.StackARN,
+			StackName:     "stack-name",
 		}
 		fakeStack = createFakeStack(fakeStackInput)
 		output.Stacks = append(output.Stacks, fakeStack)
@@ -331,9 +333,6 @@ func createFakeStack(f FakeStack) *cloudformation.Stack {
 		},
 		{
 			"instancegroups.orkaproj.io/Namespace": f.NamespaceName,
-		},
-		{
-			"EKS_GROUP_ARN": f.StackARN,
 		},
 	}
 

--- a/controllers/provisioners/ekscloudformation/helpers.go
+++ b/controllers/provisioners/ekscloudformation/helpers.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -32,6 +33,18 @@ func createConfigMap(k kubernetes.Interface, cmData *corev1.ConfigMap) error {
 		}
 	}
 	return nil
+}
+
+func (ctx *EksCfInstanceGroupContext) isResourceDeleting(s schema.GroupVersionResource, namespace, name string) (bool, error) {
+	obj, err := ctx.KubernetesClient.KubeDynamic.Resource(s).Namespace(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	deletionTimestamp := obj.GetDeletionTimestamp()
+	if !deletionTimestamp.IsZero() {
+		return true, nil
+	}
+	return false, nil
 }
 
 func updateConfigMap(k kubernetes.Interface, cmData *corev1.ConfigMap) error {

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -42,6 +42,9 @@ func (m *AwsAuthConfigMapRolesData) AddUnique(config AwsAuthConfig) {
 			return
 		}
 	}
+	if config.RoleARN == "" || config.Username == "" || len(config.Groups) == 0 {
+		return
+	}
 	m.MapRoles = append(m.MapRoles, config)
 }
 

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -48,17 +48,6 @@ func (m *AwsAuthConfigMapRolesData) AddUnique(config AwsAuthConfig) {
 	m.MapRoles = append(m.MapRoles, config)
 }
 
-func (m *AwsAuthConfigMapRolesData) Remove(config AwsAuthConfig) {
-	for i := len(m.MapRoles) - 1; i >= 0; i-- {
-		role := m.MapRoles[i]
-
-		if reflect.DeepEqual(role, config) {
-			m.MapRoles = append(m.MapRoles[:i],
-				m.MapRoles[i+1:]...)
-		}
-	}
-}
-
 // EksCfInstanceGroupContext defines the main type of an EKS Cloudformation provisioner
 type EksCfInstanceGroupContext struct {
 	InstanceGroup    *v1alpha1.InstanceGroup

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 package ekscloudformation
 
 import (
+	"reflect"
+
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/orkaproj/instance-manager/api/v1alpha1"
@@ -32,6 +34,26 @@ type AwsAuthConfig struct {
 
 type AwsAuthConfigMapRolesData struct {
 	MapRoles []AwsAuthConfig `yaml:"mapRoles"`
+}
+
+func (m *AwsAuthConfigMapRolesData) AddUnique(config AwsAuthConfig) {
+	for _, existingConf := range m.MapRoles {
+		if reflect.DeepEqual(existingConf, config) {
+			return
+		}
+	}
+	m.MapRoles = append(m.MapRoles, config)
+}
+
+func (m *AwsAuthConfigMapRolesData) Remove(config AwsAuthConfig) {
+	for i := len(m.MapRoles) - 1; i >= 0; i-- {
+		role := m.MapRoles[i]
+
+		if reflect.DeepEqual(role, config) {
+			m.MapRoles = append(m.MapRoles[:i],
+				m.MapRoles[i+1:]...)
+		}
+	}
 }
 
 // EksCfInstanceGroupContext defines the main type of an EKS Cloudformation provisioner

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -206,3 +206,10 @@ func (d *DiscoveredInstanceGroup) GetScalingGroupName() string {
 	}
 	return ""
 }
+
+func (d *DiscoveredInstanceGroup) GetARN() string {
+	if d != nil {
+		return d.ARN
+	}
+	return ""
+}

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -203,6 +203,10 @@ type DiscoveredInstanceGroups struct {
 }
 
 func (groups *DiscoveredInstanceGroups) AddGroup(group DiscoveredInstanceGroup) []DiscoveredInstanceGroup {
+	if group.Name == "" || group.Namespace == "" || group.ClusterName == "" || group.StackName == "" ||
+		group.ARN == "" || group.ScalingGroupName == "" || group.LaunchConfigName == "" {
+		return groups.Items
+	}
 	groups.Items = append(groups.Items, group)
 	return groups.Items
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -252,8 +252,7 @@ ip-10-105-233-110.us-west-2.compute.internal   Ready    <none>   3m40s   v1.13.7
 
 #### Hybrid node groups
 
-In this scenario, node groups which were manually bootstrapped (above), and instance-manager managed instance groups can co-exist, however in order for bootstrapped node groups not to be affected when instance-manager modifies the aws-auth config map, the stack that created it must be tagged with `instancegroups.orkaproj.io/ClusterName: <EKS_CLUSTER_NAME>` and the stack must have an Output called `NodeInstanceRole` with the ARN if the node group IAM role, or you can also add such ARNs under `defaultArns` section of `controller.conf`.
-instance-manager will make sure to retain the ARN associated with this node group when modifying the aws-auth config map.
+In this scenario, node groups which were manually bootstrapped (as above), and instance-manager managed instance groups can co-exist, you can add such node group's ARNs under `defaultArns` section of `controller.conf` if you want instance-manager to make sure it's added, however manual entries to aws-auth config map will not be modified/stripped out.
 
 ### Deploy instance-manager
 


### PR DESCRIPTION
Fixes #26 

- Parsing of the existing `aws-auth` configmap
- Retain mapRole if it does not conflict with a node role

## Testing
-- Added some unit tests